### PR TITLE
Change repo references in workflows after github org rename

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -5,6 +5,6 @@ on:
       - opened
 jobs:
   add_to_product_board:
-    uses: flowforge/.github/.github/workflows/project-automation.yml@main
+    uses: flowfuse/.github/.github/workflows/project-automation.yml@main
     secrets:
       token: ${{ secrets.PROJECT_ACCESS_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,14 +11,14 @@ on:
 
 jobs:
   build:
-    uses: 'flowforge/github-actions-workflows/.github/workflows/build_node_package.yml@e3e734b910af78371b2c9a1c6856446d17421f50'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@e3e734b910af78371b2c9a1c6856446d17421f50'
 
   publish:
     needs: build
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@5e57b30ac6ed8478406b3b3f2780241d2f4dcd8f'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@5e57b30ac6ed8478406b3b3f2780241d2f4dcd8f'
     with:
       package_name: nr-project-nodes
       publish_package: true
@@ -40,7 +40,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: nodered-container.yml
-          repo: flowforge/helm
+          repo: flowfuse/helm
           ref: main
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"nr_project_nodes_ref": "${{ github.ref }}", "nr_project_nodes_release_name": "${{ needs.publish.outputs.release_name }}"}'
@@ -60,7 +60,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish.yml
-          repo: flowforge/flowforge-nr-launcher
+          repo: flowfuse/nr-launcher
           ref: main
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"nr_project_nodes_ref": "${{ github.ref }}", "nr_project_nodes_release_name": "${{ needs.publish.outputs.release_name }}"}'


### PR DESCRIPTION
## Description

Change repository references after Github organisation rename from `flowforge` to `flowfuse`.

## Related Issue(s)

[213](https://github.com/flowforge/admin/issues/213)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

